### PR TITLE
Convert float indices (issue #7)

### DIFF
--- a/pianoputer.py
+++ b/pianoputer.py
@@ -19,9 +19,10 @@ def stretch(snd_array, factor, window_size, h):
     """ Stretches/shortens a sound, by some factor. """
     phase = np.zeros(window_size)
     hanning_window = np.hanning(window_size)
-    result = np.zeros(len(snd_array) / factor + window_size)
+    result = np.zeros(int(len(snd_array) / factor + window_size))
 
     for i in np.arange(0, len(snd_array) - (window_size + h), h*factor):
+        i = int(i)
         # Two potentially overlapping subarrays
         a1 = snd_array[i: i + window_size]
         a2 = snd_array[i + h: i + window_size + h]


### PR DESCRIPTION
This solves the following error (issue #7):

    $ python pianoputer.py          
    Transponding sound file... Traceback (most recent call last):
      File "pianoputer.py", line 127, in <module>
        main()
      File "pianoputer.py", line 91, in main
        transposed_sounds = [pitchshift(sound, n) for n in tones]
      File "pianoputer.py", line 50, in pitchshift
        stretched = stretch(snd_array, 1.0/factor, window_size, h)
      File "pianoputer.py", line 26, in stretch
        a1 = snd_array[i: i + window_size]
    TypeError: slice indices must be integers or None or have an __index__ method

The solution was suggested by @wupanhao.