### PR TITLE
Rev rolls to 2.0.2, adds long_description content_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+- setup.py long_description format updated to markdown
+
 ## 2.0.1
 - Fixes bug where audio files could not be loaded because mixer.init was not
   allowing the data to be modified to suit the hardware needs

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test:
 	python3 setup.py pytest
 
 dist:
+	rm -rf dist
 	python3 setup.py sdist bdist_wheel
 	rm -rf build
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name="pianoputer",
     install_requires=["librosa >= 0.8.0", "pygame >= 2.0.0", "keyboardlayout >= 2.0.1"],
     python_requires=">=3",
-    version="2.0.1",
+    version="2.0.2",
     description='Use your computer keyboard as a "piano"',
     author="Zulko",
     maintainer="Justin Black",
@@ -47,4 +47,5 @@ setup(
         "Topic :: Multimedia :: Sound/Audio :: Players",
     ],
     long_description=long_description,
+    long_description_content_type='text/markdown',
 )


### PR DESCRIPTION
## 2.0.2
- setup.py long_description format updated to markdown