### PR TITLE
Fixes a small pygame bug

### DIFF
--- a/pianoputer/pianoputer.py
+++ b/pianoputer/pianoputer.py
@@ -284,9 +284,10 @@ def play_until_user_exits(
             if event.type == pygame.QUIT:
                 playing = False
                 break
-            elif event.key == pygame.K_ESCAPE:
-                playing = False
-                break
+            elif event.type == pygame.KEYDOWN:
+                if event.type == pygame.K_ESCAPE:
+                    playing = False
+                    break
 
             key = keyboard.get_key(event)
             if key is None:


### PR DESCRIPTION
### Issue:
(Using pygame 2.1.2)
Pianoputer closes itself when starting, and leaves this error:

```
line 287, in play_until_user_exits
    elif event.key == pygame.K_ESCAPE:
AttributeError: 'Event' object has no attribute 'key'
```
Not sure if this bug happens in old pygame versions
### Solution
It's needed to first check if the event type is ``pygame.KEYDOWN`` first, then check if the event key is ``pygame.K_ESCAPE``