### PR TITLE
Add Midi Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ All white and black keys are transposed up and down from the anchor cyan key.
 
 ![qwerty keyboard layout, c4 is cyan](https://raw.githubusercontent.com/Zulko/pianoputer/master/pianoputer/keyboards/qwerty_piano.jpg "qwerty keyboard layout, c4 is cyan")
 
+## Midi
+
+You can use pianoputer as a midi keybaord by using the `--midi` flag. By default, the `--midi` flag creates a virtual midi output port called "pianoputer", but you can also specify a real port,
+such as `--midi COM1` or `--midi /dev/serial0`.
+
 ## Changing the sound file
 
 You can provide your own sound file with

--- a/pianoputer/keyboards/custom_qwerty.kb
+++ b/pianoputer/keyboards/custom_qwerty.kb
@@ -1,0 +1,42 @@
+caps lock
+left shift
+a
+z
+s
+x
+tab
+1
+q
+2
+w
+e
+4
+r
+5
+t
+6
+y
+v c
+g
+b
+h
+n
+m
+k
+,
+l
+.
+;
+/
+right shift
+8
+i
+9
+o
+p
+-
+[
+=
+]
+backspace
+\

--- a/pianoputer/keyboards/qwerty_piano.txt.BAK
+++ b/pianoputer/keyboards/qwerty_piano.txt.BAK
@@ -1,42 +1,43 @@
-caps lock
-left shift
-a
-z
-s
-x
+`
 tab
 1
 q
-2
 w
+3
 e
 4
 r
 5
 t
-6 anchor
-y
+left shift
+a
+z
+s
+x
+c
+f
 v
 g
 b
 h
 n
-m
+m c
 k
 ,
 l
 .
-;
 /
+'
 right shift
+return
+u
 8
 i
-9
 o
+0
 p
 -
 [
-=
 ]
 backspace
 \

--- a/pianoputer/make_kb_file.py
+++ b/pianoputer/make_kb_file.py
@@ -7,9 +7,12 @@ kb_file = open("my_keyboard.kb", "w")
 pg.init()
 screen = pg.display.set_mode((200, 200))
 print("Press the keys in the right order. Press Escape to finish.")
+
 while True:
+
     event = pg.event.wait()
-    if event.type is pg.KEYDOWN:
+
+    if event.type == pg.KEYDOWN:
         if event.key == pg.K_ESCAPE:
             break
         else:

--- a/pianoputer/pianoputer.py
+++ b/pianoputer/pianoputer.py
@@ -311,7 +311,7 @@ def play_until_user_exits(
             keyN = keys.index(key) + os.environ.get("MIDI_KEY_OFFSET", 37)
 
             if event.type == pygame.KEYDOWN:
-                 if not midi:
+                if not midi:
                     sound.stop()
                     sound.play(fade_ms=SOUND_FADE_MILLISECONDS)
                 else:

--- a/pianoputer/pianoputer.py
+++ b/pianoputer/pianoputer.py
@@ -16,6 +16,7 @@ import librosa
 import numpy
 import pygame
 import soundfile
+import mido
 
 ANCHOR_INDICATOR = " anchor"
 ANCHOR_NOTE_REGEX = re.compile(r"\s[abcdefg]$")
@@ -33,6 +34,9 @@ KEYBOARD_ASSET_PREFIX = "keyboards/"
 CURRENT_WORKING_DIR = Path(__file__).parent.absolute()
 ALLOWED_EVENTS = {pygame.KEYDOWN, pygame.KEYUP, pygame.QUIT}
 
+# declare globals
+midi = False
+midout = None
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=DESCRIPTION)
@@ -60,6 +64,14 @@ def get_parser() -> argparse.ArgumentParser:
         default=False,
         action="store_true",
         help="deletes stored transposed audio files and recalculates them",
+    )
+    parser.add_argument(
+        "--midi", "-m",
+        type=str,
+        help="enable midi, and provide midi port (optional)",
+        nargs='?',
+        default=None,
+        const="pianoputer"
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="verbose mode")
 
@@ -99,10 +111,10 @@ def get_or_create_key_sounds(
                 )
             )
             if channels == 1:
-                sound = librosa.effects.pitch_shift(y, sr, n_steps=tone)
+                sound = librosa.effects.pitch_shift(y=y, sr=sr, n_steps=tone)
             else:
                 new_channels = [
-                    librosa.effects.pitch_shift(y[i], sr, n_steps=tone)
+                    librosa.effects.pitch_shift(y=y[i], sr=sr, n_steps=tone)
                     for i in range(channels)
                 ]
                 sound = numpy.ascontiguousarray(numpy.vstack(new_channels).T)
@@ -296,11 +308,20 @@ def play_until_user_exits(
             except KeyError:
                 continue
 
+            keyN = keys.index(key) + os.environ.get("MIDI_KEY_OFFSET", 37)
+
             if event.type == pygame.KEYDOWN:
-                sound.stop()
-                sound.play(fade_ms=SOUND_FADE_MILLISECONDS)
+                 if not midi:
+                    sound.stop()
+                    sound.play(fade_ms=SOUND_FADE_MILLISECONDS)
+                else:
+                    midout.send(mido.Message('note_on', note=keyN, velocity=100))
+
             elif event.type == pygame.KEYUP:
-                sound.fadeout(SOUND_FADE_MILLISECONDS)
+                if not midi:
+                    sound.fadeout(SOUND_FADE_MILLISECONDS)
+                else:
+                    midout.send(mido.Message('note_off', note=keyN, velocity=0))
 
     pygame.quit()
     print("Goodbye")
@@ -333,12 +354,19 @@ def process_args(parser: argparse.ArgumentParser, args: Optional[List]) -> Tuple
     keyboard_path = args.keyboard
     if keyboard_path.startswith(KEYBOARD_ASSET_PREFIX):
         keyboard_path = os.path.join(CURRENT_WORKING_DIR, keyboard_path)
-    return wav_path, keyboard_path, args.clear_cache
 
+    return wav_path, keyboard_path, args.clear_cache, args.midi
 
 def play_pianoputer(args: Optional[List[str]] = None):
+
+    global midi, midout
+
     parser = get_parser()
-    wav_path, keyboard_path, clear_cache = process_args(parser, args)
+    wav_path, keyboard_path, clear_cache, midi = process_args(parser, args)
+
+    if midi:
+        midout = mido.open_output(midi, virtual=not (midi.startswith("COM") or midi.startswith("/dev/")), use_environ=True)
+
     audio_data, framerate_hz, channels = get_audio_data(wav_path)
     results = get_keyboard_info(keyboard_path)
     keys, tones, color_to_key, key_color, key_txt_color = results


### PR DESCRIPTION
Turns pianoputer into a midi-output device, using [`mido`](https://pypi.org/project/mido/).

The `--midi` flag enables/disables midi usage (audio output is turned off when using midi), and allows a midi port (or virtual midi device) to be specified. Uses a fixed note velocity of 100.

For mismatched midi-key-numbers, an optional `MIDI_KEY_OFFSET` environment variable is available (default: `37` works for the default keyboard layout), and mido settings can be configured through environment variables (see [Mido - Environment Variables](https://mido.readthedocs.io/en/latest/backends/index.html#environment-variables))

also fixes #31.